### PR TITLE
Add basic tox config

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,8 @@
+[tox]
+envlist = py27, py34, py35
+
+[testenv]
+deps= -r{toxinidir}/requirements.txt
+whitelist_externals = make
+commands=
+    make test


### PR DESCRIPTION
For running tests on py27, py34, py35.

No idea how to integrate this with anaconda, tho.
