### PR TITLE
patch NR pipeline

### DIFF
--- a/dammit/databases.py
+++ b/dammit/databases.py
@@ -139,6 +139,7 @@ def build_default_pipeline(handler, config, databases, with_uniref=False, with_n
     if with_uniref:
         register_uniref90_tasks(handler, config['last']['lastdb'], databases)
     if with_nr:
+        register_uniref90_tasks(handler, config['last']['lastdb'], databases)
         register_nr_tasks(handler, config['last']['lastdb'], databases)
 
     return handler


### PR DESCRIPTION
NR pipeline was attempting to run uniref90 without registering the database task. Not sure if this is the best way to fix it, but it does the job.