### PR TITLE
Stop using conda build for travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,8 +19,7 @@ install:
   - conda config --add channels conda-forge
   - conda create -n test python=$TRAVIS_PYTHON_VERSION
   - source activate test
-  - conda install conda-build
-  - conda build recipe/
-  - conda install dammit --use-local
+  - conda install python numpy pandas numexpr>=2.3.1 khmer>=2.1 sphinx>1.3.1 sphinx_rtd_theme>=0.1.9 pytest pytest-runner doit>=0.29.0 matplotlib shmlast infernal hmmer transdecoder=3.0.1 last busco=3.0.2 parallel bioconductor-seqlogo
+  - python setup.py install
 
 script: make ci-test


### PR DESCRIPTION
Directly installs the conda dependencies rather than using conda-build on the `recipe/` folder.